### PR TITLE
Issue Ticket #4: Updated Deprecated Imports

### DIFF
--- a/backend/agents/agent_loader.py
+++ b/backend/agents/agent_loader.py
@@ -13,7 +13,7 @@ import os
 from dotenv import load_dotenv
 from langchain.agents import initialize_agent
 from langchain.agents.agent_types import AgentType
-from langchain.chat_models import ChatOpenAI
+from langchain_community.chat_models import ChatOpenAI
 from backend.tools.registry import tools
 
 # Load environment variables at module level

--- a/backend/api/query.py
+++ b/backend/api/query.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Form
 from fastapi.responses import StreamingResponse, JSONResponse
 from dotenv import load_dotenv
-from langchain.chat_models import ChatOpenAI
+from langchain_community.chat_models import ChatOpenAI
 from ..core.vector_store import VectorStore
 from ..prompts.prompt_manager import PromptManager
 

--- a/backend/core/embeddings.py
+++ b/backend/core/embeddings.py
@@ -10,7 +10,7 @@ TODO:
 """
 
 import os
-from langchain.embeddings import OpenAIEmbeddings
+from langchain_community.embeddings import OpenAIEmbeddings
 
 class EmbeddingProvider:
     """

--- a/backend/core/vectordatabase.py
+++ b/backend/core/vectordatabase.py
@@ -6,7 +6,7 @@ TODO:
 - Customize embedding provider as needed.
 """
 
-from langchain.vectorstores import FAISS
+from langchain_community.vectorstores import FAISS
 from backend.core.embeddings import EmbeddingProvider
 
 class VectorDatabase:


### PR DESCRIPTION
Issue Ticket #4: Replaced deprecated `langchain.x` imports with `langchain_community.x`. These three (chat_models, embeddings, and vectorstores) were all logging warnings in the console.