### PR TITLE
Issue Ticket #6: Updated Deprecated Imports - ChatOpenAI

### DIFF
--- a/backend/agents/agent_loader.py
+++ b/backend/agents/agent_loader.py
@@ -13,7 +13,7 @@ import os
 from dotenv import load_dotenv
 from langchain.agents import initialize_agent
 from langchain.agents.agent_types import AgentType
-from langchain_community.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from backend.tools.registry import tools
 
 # Load environment variables at module level

--- a/backend/api/query.py
+++ b/backend/api/query.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Form
 from fastapi.responses import StreamingResponse, JSONResponse
 from dotenv import load_dotenv
-from langchain_community.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from ..core.vector_store import VectorStore
 from ..prompts.prompt_manager import PromptManager
 


### PR DESCRIPTION
Issue Ticket #6: Replaced deprecated imports of ChatOpenAI with the version from langchain_openai.